### PR TITLE
Fixed October issue

### DIFF
--- a/download_all_fx_data.py
+++ b/download_all_fx_data.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
                         pass  # lets download it month by month.
                     month = 1
                     while not could_download_full_year and month <= 12:
-                        output_filename = download_fx_m1_data(str(year), str(month).strip('0'), currency_pair_code)
+                        output_filename = download_fx_m1_data(str(year), str(month), currency_pair_code)
                         shutil.move(output_filename, os.path.join(output_folder, output_filename))
                         month += 1
                     year += 1


### PR DESCRIPTION
"str(month).strip('0')" will convert "10" to "1". It means January will be downloaded instead of October of current year.
As month type is int type in could_download_full_year, str(month) never makes "01". That's why "strip('0')" is unnecessary.